### PR TITLE
Fixed population after rename

### DIFF
--- a/src/views/islands.js
+++ b/src/views/islands.js
@@ -153,10 +153,11 @@ export async function islandsView(ctx) {
             ctx.setIslands(islands);
 
             ctx.population[island.url] = ctx.population[oldUrl];
-            population[island.url] = population[oldUrl];
+            popSummary[island.url] = popSummary[oldUrl];
+            delete ctx.population[oldUrl];
+            delete popSummary[oldUrl];
 
-            delete ctx.popSettings[oldUrl];
-            delete popSettings[oldUrl];
+            ctx.setPopulation(ctx.population);
 
             update();
         }

--- a/src/views/islands.js
+++ b/src/views/islands.js
@@ -142,6 +142,7 @@ export async function islandsView(ctx) {
         const index = islands.findIndex(i => id == i.objectId);
         const island = islands[index];
 
+        const oldUrl = island.url;
         const newName = prompt(`Enter new name for ${island.name}`, island.name);
 
         if (newName) {
@@ -150,6 +151,12 @@ export async function islandsView(ctx) {
             const result = await updateIsland(id, island);
             Object.assign(island, result);
             ctx.setIslands(islands);
+
+            ctx.population[island.url] = ctx.population[oldUrl];
+            population[island.url] = population[oldUrl];
+
+            delete ctx.popSettings[oldUrl];
+            delete popSettings[oldUrl];
 
             update();
         }


### PR DESCRIPTION
When renaming an island, the population gets lost locally, so the population needs to be updated after the island url rename.